### PR TITLE
fix: resolve component type error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: 'Install dependencies'
-        run: 'yarn install --frozen-lockfile && yarn bootstrap'
+        run: 'yarn install --frozen-lockfile'
 
       - name: 'Type Check'
         run: 'yarn type-check'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,39 @@
+name: 'PR Workflow'
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Get Yarn cache path'
+        id: 'yarn-cache'
+        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
+
+      - name: 'Checkout'
+        uses: 'actions/checkout@master'
+
+      - name: 'Enable node'
+        uses: 'actions/setup-node@master'
+        with:
+          node-version: '14.x'
+
+      - name: 'Load Yarn cache'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.yarn-cache.outputs.dir }}'
+          key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: 'Install dependencies'
+        run: 'yarn install --frozen-lockfile && yarn bootstrap'
+
+      - name: 'Type Check'
+        run: 'yarn type-check'
+
+      - name: 'Build packages'
+        run: 'yarn build'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "preconstruct build && manypkg run site build",
     "postinstall": "preconstruct dev",
     "start": "manypkg run site dev",
+    "type-check": "manypkg run site type-check",
     "test": "jest"
   },
   "dependencies": {

--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@effectiveopensource/rehype-highlight-code": "0.0.0",

--- a/site/src/styles/components.ts
+++ b/site/src/styles/components.ts
@@ -89,8 +89,7 @@ export const Stack = styled('div', {
 
 export const Container = styled('div', {
   width: '100%',
-  marginLeft: 'auto',
-  marginRight: 'auto',
+  mx: '$auto',
   maxWidth: '50ch',
   position: 'static',
 

--- a/site/src/styles/components.ts
+++ b/site/src/styles/components.ts
@@ -89,7 +89,8 @@ export const Stack = styled('div', {
 
 export const Container = styled('div', {
   width: '100%',
-  mx: 'auto',
+  marginLeft: 'auto',
+  marginRight: 'auto',
   maxWidth: '50ch',
   position: 'static',
 

--- a/site/src/styles/system.ts
+++ b/site/src/styles/system.ts
@@ -37,6 +37,7 @@ export const {
       xxl: '2.5rem',
     },
     space: {
+      auto: 'auto',
       none: '0rem',
       xxs: '0.25rem',
       xs: '0.5rem',


### PR DESCRIPTION
This change resolves the previous deployment failure by updating a prop that caused an error due to mismatched types in our `stitches` system. It also adds a `type-check` script to avoid this in the future, and a PR actions workflow to run it (and also `build`).