### PR TITLE
ci: add "push to main" workflow

### DIFF
--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -1,0 +1,39 @@
+name: '"Push to Main" Workflow'
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Get Yarn cache path'
+        id: 'yarn-cache'
+        run: 'echo "::set-output name=dir::$(yarn cache dir)"'
+
+      - name: 'Checkout'
+        uses: 'actions/checkout@master'
+
+      - name: 'Enable node'
+        uses: 'actions/setup-node@master'
+        with:
+          node-version: '14.x'
+
+      - name: 'Load Yarn cache'
+        uses: 'actions/cache@v2'
+        with:
+          path: '${{ steps.yarn-cache.outputs.dir }}'
+          key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: 'Install dependencies'
+        run: 'yarn install --frozen-lockfile'
+
+      - name: 'Type Check'
+        run: 'yarn type-check'
+
+      - name: 'Build packages'
+        run: 'yarn build'


### PR DESCRIPTION
This runs the same workflow as PRs but when a commit is made to `main`. 